### PR TITLE
fix: Correct MCC Y-axis inversion and add interpolation display

### DIFF
--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -48,3 +48,6 @@ class DataManager:
         self.dta_map: Optional[np.ndarray] = None
         self.dd_stats: Optional[Dict[str, float]] = None
         self.dta_stats: Optional[Dict[str, float]] = None
+
+        # Display options
+        self.use_mcc_interpolation: bool = True  # Use interpolated MCC data for smoother visualization

--- a/src/load_mcc.py
+++ b/src/load_mcc.py
@@ -103,7 +103,7 @@ def load_mcc(filename: str, target_resolution: float = 2.0) -> StandardDoseData:
             origin_x_idx, origin_y_idx, spacing = 13, 13, 10.0
 
         x_coords_raw = (np.arange(width) - origin_x_idx) * spacing
-        y_coords_raw = (np.arange(height) - origin_y_idx) * spacing
+        y_coords_raw = -((np.arange(height) - origin_y_idx) * spacing)
 
         # 3. Convert sparse data to a dense grid via interpolation
         valid_points_indices = np.where(raw_matrix >= 0)

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -213,12 +213,19 @@ class PlotManager:
 
         # Draw File B (bottom)
         if dm.file_b_handler:
-            file_b_data = dm.file_b_handler.get_pixel_data()
+            # Use interpolated data if option is enabled and method is available
+            if dm.use_mcc_interpolation and hasattr(dm.file_b_handler, 'get_interpolated_matrix_data'):
+                file_b_data = dm.file_b_handler.get_interpolated_matrix_data(method='cubic')
+                title_suffix = ' (Interpolated)'
+            else:
+                file_b_data = dm.file_b_handler.get_pixel_data()
+                title_suffix = ''
+
             file_b_extent = dm.file_b_handler.get_physical_extent()
             if file_b_data is not None and file_b_extent is not None:
                 draw_image(
                     canvas=self.mcc_canvas, image_data=file_b_data,
-                    extent=file_b_extent, title='File B (Bottom)',
+                    extent=file_b_extent, title=f'File B (Bottom){title_suffix}',
                     colorbar_label='Dose (Gy)', show_origin=True, show_colorbar=True,
                     line=dm.profile_line
                 )


### PR DESCRIPTION
- Fix Y-axis coordinate calculation in load_mcc.py by adding negative sign to match reference implementation (fixes vertical flip issue)
- Add use_mcc_interpolation option to DataManager (default: True)
- Update UI to display interpolated MCC data for smoother visualization
- Use cubic interpolation method from get_interpolated_matrix_data()