### PR TITLE
fix: Correct 2D dose display orientation and report generation

### DIFF
--- a/src/app_controller.py
+++ b/src/app_controller.py
@@ -76,8 +76,13 @@ class AppController:
             # Update legacy references for backward compatibility
             if file_b_is_mcc:
                 dm.mcc_handler = dm.file_b_handler
+            elif file_a_is_mcc:
+                dm.mcc_handler = dm.file_a_handler
+
             if not file_a_is_mcc:
                 dm.dicom_handler = dm.file_a_handler
+            elif not file_b_is_mcc:
+                dm.dicom_handler = dm.file_b_handler
 
             self.plot_manager.draw_gamma_map()
 
@@ -307,32 +312,54 @@ class AppController:
         if self.data_manager.gamma_stats is None:
             QMessageBox.warning(self.main_view, "Warning", "Run gamma analysis first.")
             return
+
+        dm = self.data_manager
+
+        # Check if handlers are available
+        if not dm.dicom_handler or not dm.mcc_handler:
+            QMessageBox.warning(self.main_view, "Warning", "Both DICOM and MCC handlers must be available to generate report.")
+            return
+
         try:
             base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
             report_dir = os.path.join(base_dir, 'Report')
             os.makedirs(report_dir, exist_ok=True)
-            patient_id = self.data_manager.dicom_data.metadata.get('patient_id', 'Unknown')
-            dicom_filename_base = os.path.splitext(os.path.basename(self.data_manager.dicom_data.metadata.get('filename', 'file')))[0]
+
+            # Get patient info from DICOM handler
+            institution, patient_id, patient_name = dm.dicom_handler.get_patient_info()
+            dicom_filename = dm.dicom_handler.get_filename()
+            dicom_filename_base = os.path.splitext(dicom_filename)[0] if dicom_filename else 'file'
+
             default_path = os.path.join(report_dir, f"report_{patient_id}_{dicom_filename_base}.jpg")
             output_path, _ = QFileDialog.getSaveFileName(self.main_view, "Save Report", default_path, "JPEG Image (*.jpg *.jpeg);;PDF Document (*.pdf)")
             if not output_path: return
 
-            original_profile_line = self.data_manager.profile_line
-            self.data_manager.profile_line = {"type": "vertical", "x": 0}
+            original_profile_line = dm.profile_line
+            dm.profile_line = {"type": "vertical", "x": 0}
             ver_profile = self.plot_manager.generate_profile_data()
-            self.data_manager.profile_line = {"type": "horizontal", "y": 0}
+            dm.profile_line = {"type": "horizontal", "y": 0}
             hor_profile = self.plot_manager.generate_profile_data()
-            self.data_manager.profile_line = original_profile_line
+            dm.profile_line = original_profile_line
 
-            # The dose_bounds argument is replaced by the ROI's extent.
-            report_extent = self.data_manager.dicom_roi.physical_extent if self.data_manager.dicom_roi else None
             generate_report(
-                output_path=output_path, dicom_data=self.data_manager.dicom_data, mcc_data=self.data_manager.mcc_data,
-                gamma_map=self.data_manager.gamma_map, gamma_stats=self.data_manager.gamma_stats,
-                dta=self.main_view.dta_spin.value(), dd=self.main_view.dd_spin.value(), suppression_level=10,
-                ver_profile_data=ver_profile, hor_profile_data=hor_profile,
-                mcc_interp_data=self.data_manager.mcc_interp_data, dd_stats=self.data_manager.dd_stats, dta_stats=self.data_manager.dta_stats,
-                dose_bounds=report_extent
+                output_path=output_path,
+                dicom_handler=dm.dicom_handler,
+                mcc_handler=dm.mcc_handler,
+                gamma_map=dm.gamma_map,
+                gamma_stats=dm.gamma_stats,
+                dta=self.main_view.dta_spin.value(),
+                dd=self.main_view.dd_spin.value(),
+                suppression_level=10,
+                ver_profile_data=ver_profile,
+                hor_profile_data=hor_profile,
+                mcc_interp_data=dm.mcc_interp_data,
+                dd_map=dm.dd_map,
+                dta_map=dm.dta_map,
+                dd_stats=dm.dd_stats,
+                dta_stats=dm.dta_stats,
+                gamma_map_interp=dm.gamma_map_interp,
+                dd_map_interp=dm.dd_map_interp,
+                dta_map_interp=dm.dta_map_interp
             )
             QMessageBox.information(self.main_view, "Success", f"Report saved to:\n{output_path}")
         except Exception as e:

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -83,7 +83,7 @@ def generate_report(
     dicom_data = dicom_handler.get_pixel_data()
     dicom_extent = dicom_handler.get_physical_extent()
     if dicom_data is not None and dicom_extent is not None:
-        im_dicom = ax_dicom.imshow(dicom_data, cmap='jet', extent=dicom_extent, aspect='equal', origin='upper')
+        im_dicom = ax_dicom.imshow(dicom_data, cmap='jet', extent=dicom_extent, aspect='equal', origin='lower')
         cbar_dicom = fig.colorbar(im_dicom, ax=ax_dicom, label='Dose (Gy)', orientation='vertical', pad=0.02)
     ax_dicom.set_title('DICOM RT Dose', fontsize=12, weight='bold')
     ax_dicom.set_xlabel('Position (mm)', fontsize=10)
@@ -93,7 +93,7 @@ def generate_report(
     ax_mcc = fig.add_subplot(gs[1, 1])
     # mcc_interp_data is on the (cropped) DICOM grid
     if mcc_interp_data is not None and dicom_extent is not None:
-        im_mcc = ax_mcc.imshow(mcc_interp_data, cmap='jet', extent=dicom_extent, aspect='equal', origin='upper')
+        im_mcc = ax_mcc.imshow(mcc_interp_data, cmap='jet', extent=dicom_extent, aspect='equal', origin='lower')
         cbar_mcc = fig.colorbar(im_mcc, ax=ax_mcc, label='Dose (Gy)', orientation='vertical', pad=0.02)
 
     ax_mcc.set_title('MCC Dose (Interpolated)', fontsize=12, weight='bold')
@@ -137,13 +137,13 @@ def generate_report(
     ax_gamma = fig.add_subplot(gs[1, 2])
     if gamma_map_interp is not None and dicom_extent is not None:
         # Use interpolated gamma map on DICOM grid (no gaps)
-        im_gamma = ax_gamma.imshow(gamma_map_interp, cmap='coolwarm', extent=dicom_extent, vmin=0, vmax=2, aspect='equal', origin='upper', interpolation='bilinear')
+        im_gamma = ax_gamma.imshow(gamma_map_interp, cmap='coolwarm', extent=dicom_extent, vmin=0, vmax=2, aspect='equal', origin='lower', interpolation='bilinear')
         cbar_gamma = fig.colorbar(im_gamma, ax=ax_gamma, label='Gamma Index', orientation='vertical', pad=0.02)
     elif gamma_map is not None:
         # Fallback to sparse gamma map on MCC grid
         mcc_extent = mcc_handler.get_physical_extent()
         if mcc_extent is not None:
-            im_gamma = ax_gamma.imshow(gamma_map, cmap='coolwarm', extent=mcc_extent, vmin=0, vmax=2, aspect='equal', origin='upper')
+            im_gamma = ax_gamma.imshow(gamma_map, cmap='coolwarm', extent=mcc_extent, vmin=0, vmax=2, aspect='equal', origin='lower')
             cbar_gamma = fig.colorbar(im_gamma, ax=ax_gamma, label='Gamma Index', orientation='vertical', pad=0.02)
 
     ax_gamma.set_title(f'Gamma Analysis', fontsize=12, weight='bold')
@@ -220,13 +220,13 @@ def generate_report(
         ax_dd = fig.add_subplot(gs[2, 2])
         if dd_map_interp is not None and dicom_extent is not None:
             # Use interpolated DD map on DICOM grid (no gaps)
-            im_dd = ax_dd.imshow(dd_map_interp, cmap='viridis', extent=dicom_extent, aspect='equal', origin='upper', interpolation='bilinear')
+            im_dd = ax_dd.imshow(dd_map_interp, cmap='viridis', extent=dicom_extent, aspect='equal', origin='lower', interpolation='bilinear')
             cbar_dd = fig.colorbar(im_dd, ax=ax_dd, label='DD (%)', orientation='vertical', pad=0.02)
         elif dd_map is not None:
             # Fallback to sparse DD map on MCC grid
             mcc_extent = mcc_handler.get_physical_extent()
             if mcc_extent is not None:
-                im_dd = ax_dd.imshow(dd_map, cmap='viridis', extent=mcc_extent, aspect='equal', origin='upper')
+                im_dd = ax_dd.imshow(dd_map, cmap='viridis', extent=mcc_extent, aspect='equal', origin='lower')
                 cbar_dd = fig.colorbar(im_dd, ax=ax_dd, label='DD (%)', orientation='vertical', pad=0.02)
 
         ax_dd.set_title(f'Dose Difference (DD) Map', fontsize=12, weight='bold')
@@ -238,13 +238,13 @@ def generate_report(
         ax_dta = fig.add_subplot(gs[2, 3])
         if dta_map_interp is not None and dicom_extent is not None:
             # Use interpolated DTA map on DICOM grid (no gaps)
-            im_dta = ax_dta.imshow(dta_map_interp, cmap='plasma', extent=dicom_extent, aspect='equal', origin='upper', interpolation='bilinear')
+            im_dta = ax_dta.imshow(dta_map_interp, cmap='plasma', extent=dicom_extent, aspect='equal', origin='lower', interpolation='bilinear')
             cbar_dta = fig.colorbar(im_dta, ax=ax_dta, label='DTA (mm)', orientation='vertical', pad=0.02)
         elif dta_map is not None:
             # Fallback to sparse DTA map on MCC grid
             mcc_extent = mcc_handler.get_physical_extent()
             if mcc_extent is not None:
-                im_dta = ax_dta.imshow(dta_map, cmap='plasma', extent=mcc_extent, aspect='equal', origin='upper')
+                im_dta = ax_dta.imshow(dta_map, cmap='plasma', extent=mcc_extent, aspect='equal', origin='lower')
                 cbar_dta = fig.colorbar(im_dta, ax=ax_dta, label='DTA (mm)', orientation='vertical', pad=0.02)
 
         ax_dta.set_title(f'Distance to Agreement (DTA) Map', fontsize=12, weight='bold')

--- a/src/ui_components.py
+++ b/src/ui_components.py
@@ -63,7 +63,7 @@ def draw_image(canvas, image_data, extent, title, colorbar_label=None,
         image_data,
         cmap='jet',
         extent=extent,
-        origin='upper'
+        origin='lower'
     )
     
     if show_colorbar and colorbar_label is not None:


### PR DESCRIPTION
Fixed two critical issues:

1. MCC 2D dose vertical flip:
   - Changed imshow origin from 'upper' to 'lower' in all visualization functions
   - Both DICOM and MCC use Y-axis increasing upward coordinate system
   - This aligns with the coordinate system defined in file handlers
   - Applied to: ui_components.py and reporting.py

2. Report generation handler mismatch:
   - Fixed generate_report() to pass handler objects instead of data objects
   - Updated legacy handler assignment logic to handle both file loading orders:
     * a=DICOM, b=MCC (standard case)
     * a=MCC, b=DICOM (reversed case)
   - Added handler availability check before report generation
   - Removed invalid dose_bounds parameter from generate_report call

These fixes ensure proper display of 2D dose distributions and enable report generation regardless of which file is loaded as File A or B.