### PR TITLE
fix: Correct MCC data orientation for consistent UI display

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -89,11 +89,12 @@ def extract_profile_data(direction, fixed_position, dicom_handler, mcc_handler=N
 
                 mcc_values = mcc_line_values[valid_indices]
 
-                # For vertical profiles, the physical y-coordinate is descending.
-                # We sort it here to ensure all subsequent operations use ascending coordinates.
-                if sort_required:
-                    mcc_phys_coords = mcc_phys_coords[::-1]
-                    mcc_values = mcc_values[::-1]
+                # matrix_data가 flipud되어 이미 올바른 순서이므로 역순 정렬 불필요
+                # Before: MCC는 y=-130→130 순서여서 수동 정렬 필요했음
+                # After: flipud 후 y=130→-130 순서로 DICOM과 동일
+                # if sort_required:  # 삭제됨 - flipud로 자동 해결
+                #     mcc_phys_coords = mcc_phys_coords[::-1]
+                #     mcc_values = mcc_values[::-1]
 
                 # Find corresponding DICOM values at MCC measurement points
                 dicom_at_mcc_positions = np.array([
@@ -171,7 +172,9 @@ def perform_gamma_analysis(reference_handler, evaluation_handler,
         full_grid_px = x_pix + handler.crop_pixel_offset[0]
         full_grid_py = y_pix + handler.crop_pixel_offset[1]
         phys_x_all = (full_grid_px - handler.mcc_origin_x) * handler.mcc_spacing_x
-        phys_y_all = (full_grid_py - handler.mcc_origin_y) * handler.mcc_spacing_y
+        # Y축 음수 부호: pixel_to_physical_coord()와 동일한 변환 규칙 적용
+        # matrix_data가 flipud되었으므로 음수 부호로 좌표 일관성 유지
+        phys_y_all = -(full_grid_py - handler.mcc_origin_y) * handler.mcc_spacing_y
         all_mcc_coords_phys = np.vstack((phys_x_all, phys_y_all)).T
 
         all_mcc_dose_values = mcc_dose_data[all_valid_indices]

--- a/src/file_handlers.py
+++ b/src/file_handlers.py
@@ -393,7 +393,13 @@ class MCCFileHandler(BaseFileHandler):
 
             N_begin = content.count("BEGIN_DATA")
             self.n_rows = N_begin
-            self.matrix_data = self.extract_data(lines, N_begin, self.device_type, self.task_type)
+
+            # MCC 파일은 Y축이 -130 → 130 순서로 배열되어 있으므로 flipud 필요
+            # DICOM과 일관성: array[0, :] = y_max (위쪽 데이터)
+            # Before flipud: matrix_data[0, :] = y_min (아래쪽) → UI에서 상하반전 발생
+            # After flipud: matrix_data[0, :] = y_max (위쪽) → 정상 표시
+            raw_matrix = self.extract_data(lines, N_begin, self.device_type, self.task_type)
+            self.matrix_data = np.flipud(raw_matrix)
             self.pixel_data = self.matrix_data
 
             self._set_device_parameters()
@@ -569,5 +575,8 @@ class MCCFileHandler(BaseFileHandler):
         full_grid_py = pixel_y + self.crop_pixel_offset[1]
 
         phys_x = (full_grid_px - self.mcc_origin_x) * self.mcc_spacing_x
-        phys_y = (full_grid_py - self.mcc_origin_y) * self.mcc_spacing_y
+        # Y축 음수 부호: matrix_data flipud 후 create_physical_coordinates_mcc()의 음수와 일치시킴
+        # py=0 (flipud 후 위쪽) → phys_y = -(0-26)*5 = 130 (y_max)
+        # py=26 (flipud 후 아래쪽) → phys_y = -(26-26)*5 = -130 (y_min)
+        phys_y = -(full_grid_py - self.mcc_origin_y) * self.mcc_spacing_y
         return phys_x, phys_y


### PR DESCRIPTION
Problem:
- MCC UI 2D dose display showed vertical flip (상하반전)
- MCC file Y-axis data stored as -130 → 130 (bottom to top)
- DICOM expects array[0, :] to represent y_max (top data)

Root Cause:
- create_physical_coordinates_mcc() uses negated Y: phys_y[0] = y_max
- But matrix_data[0, :] contained y_min data → mismatch
- imshow(origin='upper') displays array[0] at top → vertical flip

Solution:
1. file_handlers.py:396-402
   - Apply np.flipud() to raw MCC data after loading
   - Now matrix_data[0, :] = y_max (top data) matching DICOM

2. file_handlers.py:572-581
   - Restore negative sign in pixel_to_physical_coord()
   - Maintains consistency with create_physical_coordinates_mcc()
   - py=0 (top after flip) → phys_y = 130 (y_max) ✓

3. analysis.py:174-176
   - Add negative sign in gamma analysis coordinate conversion
   - Matches pixel_to_physical_coord() transformation rule

4. analysis.py:92-97
   - Remove vertical profile reverse sorting
   - No longer needed after flipud - data already in correct order

Benefits:
- MCC UI 2D dose now displays correctly (no vertical flip)
- All coordinate transformations use consistent rules
- Profile extraction works automatically without manual sorting
- Gamma map and reports remain correct
- Full consistency with DICOM coordinate system

🤖 Generated with [Claude Code](https://claude.com/claude-code)