### PR TITLE
fix: Correct MCC file loading interpolation and extrapolation issues

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -105,11 +105,12 @@ def extract_profile_data(direction, fixed_position, dicom_handler, mcc_handler=N
                 if len(mcc_values) > 1:
                     # The coordinate arrays are now guaranteed to be ascending,
                     # so we can interpolate directly.
-                    # Use extrapolation to extend the interpolated line beyond MCC data points
+                    # Limit interpolation to measured range only (no extrapolation)
                     mcc_interp = np.interp(
                         profile_coords_dicom,
                         mcc_phys_coords,
-                        mcc_values
+                        mcc_values,
+                        left=np.nan, right=np.nan
                     )
                     profile_data['mcc_interp'] = mcc_interp
 

--- a/src/app_controller.py
+++ b/src/app_controller.py
@@ -247,9 +247,10 @@ class AppController:
                     handler.crop_to_bounds(self.data_manager.file_a_handler.dose_bounds)
 
             # For backward compatibility with existing code
+            # Use load_mcc() as the primary loader for standardized data processing
             if isinstance(handler, MCCFileHandler):
-                self.data_manager.mcc_handler = handler
-                mcc_data = load_mcc(filename)
+                self.data_manager.mcc_handler = handler  # Keep handler for legacy methods
+                mcc_data = load_mcc(filename)  # Primary loader with standardized interpolation (fill_value=0.0)
                 self.data_manager.mcc_data = mcc_data
                 self.data_manager.mcc_roi = self._extract_roi_from_data(mcc_data)
                 self.main_view.device_label.setText(f"Device Type: {handler.get_device_name()}")

--- a/src/file_handlers.py
+++ b/src/file_handlers.py
@@ -365,7 +365,8 @@ class MCCFileHandler(BaseFileHandler):
             np.array(list(zip(valid_points_indices[0], valid_points_indices[1]))),
             data[valid_points_indices],
             (grid_y, grid_x),
-            method=method
+            method=method,
+            fill_value=0.0
         )
         return interpolated_data
 


### PR DESCRIPTION
This commit addresses three critical issues in MCC file loading:

1. **Profile Extrapolation Fix (analysis.py)**
   - Restored `left=np.nan, right=np.nan` parameters to np.interp()
   - Prevents extrapolation beyond measured MCC data range
   - Ensures only actual measured values are displayed, not estimates

2. **Interpolation Fill Value Fix (file_handlers.py)**
   - Added `fill_value=0.0` to griddata() in get_interpolated_matrix_data()
   - Ensures consistency with load_mcc() standard loader
   - Prevents NaN values in non-interpolated regions

3. **Loading System Clarification (app_controller.py)**
   - Added comments to clarify load_mcc() as primary loader
   - MCCFileHandler kept for backward compatibility only
   - Standardizes data processing with fill_value=0.0

These changes ensure:
- No false data from extrapolation
- Consistent null value handling (-1.0 → valid >= 0)
- Unified interpolation approach across codebase
- Physical coordinate-based interpolation maintained